### PR TITLE
Initial wdat support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vs/*
 _release/*
 _debug/*
 build/*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,7 @@ set ( SRC_LIST
     src/gpuvis_graphrows.cpp
     src/gpuvis_ftrace_print.cpp
     src/gpuvis_utils.cpp
+	src/gpuvis_wdat.cpp
     src/tdopexpr.cpp
     src/ya_getopt.c
     src/MurmurHash3.cpp

--- a/src/gpuvis.cpp
+++ b/src/gpuvis.cpp
@@ -4482,7 +4482,7 @@ void MainApp::open_trace_dialog()
     else
     {
         const char *file = noc_file_dialog_open( NOC_FILE_DIALOG_OPEN,
-                                 "trace-cmd files (*.dat;*.trace;*.wdat)\0*.dat;*.trace;*.wdat\0",
+                                 "trace-cmd files (*.dat;*.trace;*.wdat;*.zip)\0*.dat;*.trace;*.wdat;*.zip\0",
                                  NULL, "trace.dat" );
 
         if ( file && file[ 0 ] )

--- a/src/gpuvis.h
+++ b/src/gpuvis.h
@@ -1091,8 +1091,8 @@ public:
 
     static int SDLCALL thread_func( void *data );
 
-    static int load_trace_file( loading_info_t *loading_info );
-    static int load_wdat_file( loading_info_t *loading_info );
+    static int load_trace_file( loading_info_t *loading_info, TraceEvents &trace_events, EventCallback trace_cb );
+    static int load_wdat_file( loading_info_t *loading_info, TraceEvents &trace_events, EventCallback trace_cb );
 
 public:
     enum trace_type_t

--- a/src/gpuvis.h
+++ b/src/gpuvis.h
@@ -1042,6 +1042,9 @@ public:
 class MainApp
 {
 public:
+    struct loading_info_t;
+
+public:
     MainApp() {}
     ~MainApp() {}
 
@@ -1088,11 +1091,24 @@ public:
 
     static int SDLCALL thread_func( void *data );
 
+    static int load_trace_file( loading_info_t *loading_info );
+    static int load_wdat_file( loading_info_t *loading_info );
+
 public:
+    enum trace_type_t
+    {
+        trace_type_invalid,
+        trace_type_trace,
+        trace_type_wdat
+    };
+
     struct loading_info_t
     {
         // State_Idle, Loading, Loaded, CancelLoading
         SDL_atomic_t state = { 0 };
+
+        // Which trace format are we loading
+        trace_type_t type = trace_type_invalid;
 
         uint64_t tracestart = 0;
         uint64_t tracelen = 0;
@@ -1118,6 +1134,8 @@ public:
     save_info_t m_saving_info;
 
     TraceWin *m_trace_win = nullptr;
+
+    trace_type_t m_trace_type = trace_type_invalid;
 
     FontInfo m_font_main;
     FontInfo m_font_small;

--- a/src/gpuvis_wdat.cpp
+++ b/src/gpuvis_wdat.cpp
@@ -1,0 +1,422 @@
+/*
+ * Copyright 2019 Valve Software
+ *
+ * All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <string>
+#include <array>
+#include <vector>
+#include <algorithm>
+#include <unordered_map>
+#include <unordered_set>
+#include <functional>
+#include <fstream>
+#include <sstream>
+#include <sys/stat.h>
+#include <SDL.h>
+
+#include "imgui/imgui.h"
+#include "imgui/imgui_internal.h"   // BeginColumns(), EndColumns(), PushColumnClipRect()
+#include "imgui/imgui_impl_sdl_gl3.h"
+
+#define GPUVIS_TRACE_IMPLEMENTATION
+#include "gpuvis_macros.h"
+
+#include "tdopexpr.h"
+#include "trace-cmd/trace-read.h"
+
+#include "stlini.h"
+#include "gpuvis_utils.h"
+#include "gpuvis_wdat.h"
+#include "gpuvis.h"
+
+#include "gpuvis_wdat.h"
+
+ /**
+  * wdat_reader_t reads a wdat file and provides each event as a set of key/value pairs
+  */
+class wdat_reader_t
+{
+public:
+    wdat_reader_t( const char *file ) :
+        mFileStream( file )
+    {
+        mFileName = file;
+    }
+
+    // return false at end of stream
+    bool parse_entry( std::istringstream &stream, std::string &key, std::string &val )
+    {
+        std::string garbage;
+
+        std::getline( stream, key, '=' );
+        if ( stream.fail() )
+            return false;
+
+        std::getline( stream, garbage, '`' );
+        if ( stream.fail() )
+            return false;
+
+        std::getline( stream, val, '`' );
+        if ( stream.fail() )
+            return false;
+
+        // Eat the last space
+        std::getline( stream, garbage, ' ' );
+        
+        return true;
+    }
+
+    std::unordered_map<std::string, std::string> get_event()
+    {
+        std::unordered_map<std::string, std::string> map = {};
+
+        if ( !mFileStream )
+            return map;
+
+        std::string entry;
+        if ( !std::getline( mFileStream, entry ) )
+            return map;
+
+        std::istringstream event( entry );
+
+        std::string key, val;
+        while ( parse_entry( event, key, val ) )
+        {
+            map[key] = val;
+        }
+
+        // Save the original text for error handling
+        map["wdat_line"] = entry;
+        
+        return map;
+    }
+
+private:
+    std::string mFileName;
+    std::ifstream mFileStream;
+};
+
+/**
+ * Helper macros for x_entry_t classes
+ */
+#define WDAT_PARSE_STR( name ) name = entry[#name];
+#define WDAT_PARSE_INT( name ) name = std::atoi( entry[#name].c_str() );
+#define WDAT_PARSE_U64( name ) name = std::stoull( entry[#name].c_str() );
+#define WDAT_PARSE_DBL( name ) name = std::stod( entry[#name] );
+
+/**
+ * The x_entry_t classes are helpers to interpret the wdat data as c++ types
+ */
+class header_entry_t
+{
+public:
+    static const int entry_id = 0;
+
+    int version;
+
+    header_entry_t( std::unordered_map<std::string, std::string> &entry )
+    {
+        WDAT_PARSE_INT( version );
+    }
+};
+
+class context_entry_t
+{
+public:
+    static const int entry_id = 1;
+
+    std::string file;
+    std::string os_version;
+    int num_cpu;
+    uint64_t start_time;
+    uint64_t end_time;
+
+    context_entry_t( std::unordered_map<std::string, std::string> &entry )
+    {
+        WDAT_PARSE_STR( file );
+        WDAT_PARSE_STR( os_version );
+        WDAT_PARSE_INT( num_cpu );
+        WDAT_PARSE_U64( start_time );
+        WDAT_PARSE_U64( end_time );
+    }
+};
+
+class event_entry_t
+{
+public:
+    uint64_t ts;
+    double ts_rms;
+    int cpu;
+    int pid;
+    int tid;
+    std::string pname;
+
+    event_entry_t( std::unordered_map<std::string, std::string> &entry )
+    {
+        WDAT_PARSE_U64( ts );
+        WDAT_PARSE_DBL( ts_rms );
+        WDAT_PARSE_INT( cpu );
+        WDAT_PARSE_INT( pid );
+        WDAT_PARSE_INT( tid );
+        WDAT_PARSE_STR( pname );
+    }
+};
+
+class steamvr_entry_t : public event_entry_t
+{
+public:
+    static const int entry_id = 2;
+
+    std::string vrevent;
+
+    steamvr_entry_t( std::unordered_map<std::string, std::string> &entry ) :
+        event_entry_t( entry )
+    {
+        WDAT_PARSE_STR( vrevent );
+    }
+};
+
+/**
+ * Parses the wdat information stream
+ *
+ * The wdat input stream is converted into a trace_info_t + a sequence of trace_event_t
+ */
+class wdat_parser_t
+{
+public:
+    wdat_parser_t( const char *file, StrPool &strpool, trace_info_t &trace_info, EventCallback &cb )
+        : mFileName( file )
+        , mStrPool( strpool )
+        , mTraceInfo( trace_info )
+        , mCallback( cb )
+        , mReader( file )
+        , mCurrentEventId( 0 )
+        , mStartTicks( 0 )
+    {
+    }
+
+    int process()
+    {
+        std::unordered_map<std::string, std::string> event;
+        for ( event = mReader.get_event(); !event.empty(); event = mReader.get_event() )
+        {
+            int event_id = std::atoi( event["id"].c_str() );
+
+            int ret;
+            switch ( event_id )
+            {
+            case header_entry_t::entry_id:
+                ret = process_header_entry( header_entry_t( event ) );
+                break;
+            case context_entry_t::entry_id:
+                ret = process_context_entry( context_entry_t( event ) );
+                break;
+            case steamvr_entry_t::entry_id:
+                ret = process_steamvr_entry( steamvr_entry_t( event ) );
+                break;
+            default:
+                logf( "[Error] unrecognized wdat entry: %s", event["wdat_line"].c_str() );
+                ret = 0;
+                break;
+            }
+        }
+
+        return 0;
+    }
+
+private:
+    const char *mFileName;
+    StrPool &mStrPool;
+    trace_info_t &mTraceInfo;
+    EventCallback &mCallback;
+
+    wdat_reader_t mReader;
+    uint32_t mCurrentEventId;
+    uint64_t mStartTicks;
+
+    int64_t ticks_to_relative_us( uint64_t ticks )
+    {
+        return ( ticks - mStartTicks ) * 100;
+    }
+
+    int process_header_entry( header_entry_t entry )
+    {
+        // Only version 1 is supported at the moment
+        return entry.version == 1 ? 0 : -1;
+    }
+
+    int process_context_entry( context_entry_t entry )
+    {
+        mStartTicks = entry.start_time;
+
+        mTraceInfo.cpus = entry.num_cpu;
+        mTraceInfo.file = entry.file;
+        mTraceInfo.uname = entry.os_version;
+        mTraceInfo.timestamp_in_us = true; // nanoseconds?
+        mTraceInfo.min_file_ts = ticks_to_relative_us( entry.start_time );
+        mTraceInfo.cpu_info.resize( entry.num_cpu );
+
+        for ( size_t cpu = 0; cpu < entry.num_cpu; cpu++ )
+        {
+            cpu_info_t &cpu_info = mTraceInfo.cpu_info[cpu];
+
+            cpu_info.file_offset = 0;
+            cpu_info.file_size = 0;
+
+            cpu_info.entries = 0;
+            cpu_info.overrun = 0;
+            cpu_info.commit_overrun = 0;
+            cpu_info.bytes = 0;
+            cpu_info.oldest_event_ts = ticks_to_relative_us( entry.start_time );;
+            cpu_info.now_ts = ticks_to_relative_us( entry.end_time );
+            cpu_info.dropped_events = 0;
+            cpu_info.read_events = 0;
+        }
+        return 0;
+    }
+
+    // In linux tgid is the process id
+    bool is_process_known( int pid )
+    {
+        return mTraceInfo.tgid_pids.m_map.find( pid ) != mTraceInfo.tgid_pids.m_map.end();
+    }
+
+    // In linux pid is the thread id
+    bool is_thread_known( int tid )
+    {
+        return mTraceInfo.pid_comm_map.m_map.find( tid ) != mTraceInfo.pid_comm_map.m_map.end();
+    }
+
+    // Process the common information for all events
+    int process_event_entry( event_entry_t entry, trace_event_t &event )
+    {
+        const char *comm = mStrPool.getstrf( "%s-%u", entry.pname.c_str(), entry.tid );
+
+        if ( !is_thread_known( entry.tid ) )
+        {
+            mTraceInfo.pid_comm_map.get_val( entry.tid, mStrPool.getstr( comm ) );
+        }
+
+        if ( !is_process_known( entry.pid ) )
+        {
+            tgid_info_t *tgid_info = mTraceInfo.tgid_pids.get_val_create( entry.pid );
+
+            if ( !tgid_info->tgid )
+            {
+                tgid_info->tgid = entry.pid;
+                tgid_info->hashval += hashstr32( comm );
+            }
+            tgid_info->add_pid( entry.tid );
+
+            // Pid --> tgid
+            mTraceInfo.pid_tgid_map.get_val( entry.tid, entry.pid );
+        }
+
+        event.pid = entry.tid;
+        event.id = mCurrentEventId++;
+        event.cpu = entry.cpu;
+        event.ts = ticks_to_relative_us( entry.ts );
+        event.comm = comm;
+        event.user_comm = comm;
+        event.seqno = 0;
+
+        return 0;
+    }
+
+    // Process steamvr event specific information
+    int process_steamvr_entry( steamvr_entry_t entry )
+    {
+        int err;
+
+        trace_event_t event;
+
+        err = process_event_entry( entry, event );
+        if ( err )
+            return err;
+
+        event.system = mStrPool.getstr( "ftrace-print" ); // For dat compatibility
+        event.name = mStrPool.getstr( "steamvr" );
+        event.numfields = 1;
+        event.fields = new event_field_t[event.numfields];
+        event.fields[0].key = mStrPool.getstr( "buf" );
+        event.fields[0].value = mStrPool.getstr( entry.vrevent.c_str() );
+        event.flags = TRACE_FLAG_FTRACE_PRINT;
+
+        return mCallback( event );
+    }
+};
+
+int read_wdat_file( const char *file, StrPool &strpool, trace_info_t &trace_info, EventCallback &cb )
+{
+    // Explicitly add idle thread at pid 0
+    trace_info.pid_comm_map.get_val( 0, strpool.getstr( "<idle>" ) );
+
+    wdat_parser_t parser( file, strpool, trace_info, cb );
+    return parser.process();
+
+    /*
+    // Find the lowest ts value in the trace file
+    trace_info.min_file_ts = std::min< int64_t >( trace_info.min_file_ts, record->ts );
+
+    trace_info.cpu_info.resize( handle->cpus );
+    for ( size_t cpu = 0; cpu < (size_t)handle->cpus; cpu++ )
+    {
+        cpu_info_t &cpu_info = trace_info.cpu_info[cpu];
+        pevent_record_t *record = tracecmd_peek_data( handle, cpu );
+
+        cpu_info.file_offset = handle->cpu_data[cpu].file_offset;
+        cpu_info.file_size = handle->cpu_data[cpu].file_size;
+
+        if ( cpu < handle->cpustats.size() )
+        {
+            const char *stats = handle->cpustats[cpu].c_str();
+
+            cpu_info.entries = geti64( stats, "entries:" );
+            cpu_info.overrun = geti64( stats, "overrun:" );
+            cpu_info.commit_overrun = geti64( stats, "commit overrun:" );
+            cpu_info.bytes = geti64( stats, "bytes:" );
+            cpu_info.oldest_event_ts = getf64( stats, "oldest event ts:" );
+            cpu_info.now_ts = getf64( stats, "now ts:" );
+            cpu_info.dropped_events = geti64( stats, "dropped events:" );
+            cpu_info.read_events = geti64( stats, "read events:" );
+
+            if ( cpu_info.oldest_event_ts )
+                cpu_info.oldest_event_ts -= trace_info.min_file_ts;
+            if ( cpu_info.now_ts )
+                cpu_info.now_ts -= trace_info.min_file_ts;
+        }
+
+        if ( record )
+        {
+            cpu_info.min_ts = record->ts - trace_info.min_file_ts;
+
+            if ( cpu_info.overrun && trace_info.trim_trace )
+                trim_ts = std::max< unsigned long long >( trim_ts, record->ts );
+        }
+    }
+
+    // Scoot to tracestart time if it was set
+    trim_ts = std::max< unsigned long long >( trim_ts, trace_info.min_file_ts + trace_info.m_tracestart );
+    */
+    return 0;
+}

--- a/src/gpuvis_wdat.h
+++ b/src/gpuvis_wdat.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 Valve Software
+ *
+ * All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef GPUVIS_WDAT_H_
+#define GPUVIS_WDAT_H_
+
+int read_wdat_file( const char *file, StrPool &strpool, trace_info_t &trace_info, EventCallback &cb );
+
+#endif // GPUVIS_WDAT_H_


### PR DESCRIPTION
Hey  @mikesart,

We've had some interest in the office for visualizing windows trace captures in gpuvis instead of gpuview. The gpuview user experience being what it is, I can't blame them :)

Following is a MR with an initial prototype for support for parsing a custom format windows trace file (wdat). It only displays vsync and SteamVR events at the moment, which is enough information to start being useful.

The wdat file is created by a separate app. It consumes an etl file, filters out all the unwanted records and creates some text based output that looks more or less like this:
```
id=`0` version=`1`
id=`1` file=`C:\Users\andres\Desktop\Merged.etl` os_version=`10.0` num_cpu=`8` start_time=`636904208644642487` end_time=`636904208711368889`
id=`3` ts=`636904208649240026` ts_rms=`459.753970645755` cpu=`0` pid=`12916` tid=`19308` pname=`vrcompositor` adapter=`18446608891935145984` display=`24833` address=`0`
id=`2` ts=`636904208651369527` ts_rms=`672.704014568118` cpu=`4` pid=`12916` tid=`19308` pname=`vrcompositor` vrevent=`[Compositor] End Frame Timing: 27065`
```

Then gpuvis just consumes the above to generate the trace_info_t and trace_event_t stream. The implementation which can be seen in the gpuvis_wdat.cpp parser.

Some of things I still have leftover to do:
  * Remove the wdat intermediate format, parse etl directly in gpuvis
    * Having a custom format made things a little easier to prototype, but it isn't very efficient storage wise
  * Need to pair up events that have Begin/End pairs etc.
  * Add support for CPU/GPU so we can also visualize the HW queues.

This MR isn't really intended to be merged yet. It is mostly to start a discussion about the direction that I'm headed, and to synchronize with you if you agree I should keep going down this road or take a different approach.

Regards,
Andres

